### PR TITLE
Change ocaml minimal version

### DIFF
--- a/zelus.opam
+++ b/zelus.opam
@@ -8,7 +8,7 @@ homepage: "http://zelus.di.ens.fr"
 doc: "http://zelus.di.ens.fr/man/"
 bug-reports: "https://gitlab.inria.fr/parkas/zelus/-/issues"
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.08.1"}
   "dune" {>= "2.6" & build}
   "ocamlfind"
   "menhir"


### PR DESCRIPTION
J'ai testé et ça fonctionne avec ocaml 4.08.1 (dans un nouveau switch).

Par contre, le seul message affiché par `opam install .` en cas d'incompatibilité entre la version locale d'ocaml et la version de `zelus.opam` est :
`Sorry, no solution found: there seems to be a problem with your request. No solution found, exiting`
Pas très intuitif...