### PR TITLE
Fix compilation under Sundials/ML 5.8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,17 @@ jobs:
           - gtk
           - nogtk
         ocaml-version:
-          - 4.11.1
+          - 4.13.1
           - 4.08.1
 
     steps:
-      - name: Install external dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install gcc wget cmake
-        
+      - name: Checkout code
+        uses: actions/checkout@v2
+
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-version }}
         
       - name: Install OCaml dependencies
         run: opam install -y graphics ocamlfind menhir
@@ -39,9 +37,6 @@ jobs:
         if: matrix.solver == 'sundials'
         run: opam install -y sundialsml
 
-      - name: Checkout code
-        uses: actions/checkout@v2
-      
       - name: Install Zelus
         run: |
           opam pin -y -n -k path .
@@ -49,9 +44,7 @@ jobs:
 
       - name: Install Gtk
         if: matrix.plot == 'gtk'
-        run: |
-          sudo apt-get -y install gtk2.0
-          opam install -y lablgtk zelus-gtk
+        run: opam install -y zelus-gtk
 
       - name: Build all examples
         if: matrix.plot == 'gtk'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,15 +37,7 @@ jobs:
 
       - name: Install sundials
         if: matrix.solver == 'sundials'
-        run: |
-          wget -nv --show-progress --progress=bar:force:noscroll https://github.com/LLNL/sundials/releases/download/v3.2.1/sundials-3.2.1.tar.gz
-          tar xzf sundials-3.2.1.tar.gz
-          mkdir sundials-3.2.1-build
-          cd sundials-3.2.1-build
-          cmake ../sundials-3.2.1
-          make -j
-          sudo make install
-          opam install -y sundialsml
+        run: opam install -y sundialsml
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,13 @@ jobs:
       - name: Install OCaml dependencies
         run: opam install -y graphics ocamlfind menhir
 
-      - name: Install sundials
+      - name: Install Sundials
         if: matrix.solver == 'sundials'
-        run: opam install -y sundialsml
+        run: opam depext conf-sundials
+
+      - name: Install Sundials/ML
+        if: matrix.solver == 'sundials'
+        run: opam install sundialsml
 
       - name: Install Zelus
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -10,22 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - name: Install external dependencies
-        run: |
-          sudo apt-get -y update
-          sudo apt-get -y install gcc wget cmake gtk2.0
-        
-      - name: Use OCaml
-        uses: avsm/setup-ocaml@v1
-        with:
-          ocaml-version: 4.11.1
-        
-      - name: Install OCaml dependencies
-        run: opam install -y graphics sundialsml zelus zelus-gtk
-      
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Use OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.13.1
+            
+      - name: Install OCaml dependencies
+        run: opam install -y graphics sundialsml zelus zelus-gtk
+      
       - name: Build all examples
         run: |
           cd examples 

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -14,16 +14,6 @@ jobs:
         run: |
           sudo apt-get -y update
           sudo apt-get -y install gcc wget cmake gtk2.0
-
-      - name: Install sundials
-        run: |
-          wget -nv --show-progress --progress=bar:force:noscroll https://github.com/LLNL/sundials/releases/download/v3.2.1/sundials-3.2.1.tar.gz
-          tar xzf sundials-3.2.1.tar.gz
-          mkdir sundials-3.2.1-build
-          cd sundials-3.2.1-build
-          cmake ../sundials-3.2.1
-          make -j
-          sudo make install
         
       - name: Use OCaml
         uses: avsm/setup-ocaml@v1

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -19,7 +19,9 @@ jobs:
           ocaml-compiler: 4.13.1
             
       - name: Install OCaml dependencies
-        run: opam install -y graphics sundialsml zelus zelus-gtk
+        run: |
+          opam depext sundialsml
+          opam install graphics sundialsml zelus zelus-gtk
       
       - name: Build all examples
         run: |

--- a/lib/std/solvers/solvers.sundials.ml
+++ b/lib/std/solvers/solvers.sundials.ml
@@ -11,8 +11,7 @@ module Sundials_cvode = struct
   type rhsfn = float -> Zls.carray -> Zls.carray -> unit
   type dkyfn = nvec -> float -> int -> unit
 
-  let initialize (f : rhsfn) c =
-    Cvode.init Cvode.Adams Cvode.Functional Cvode.default_tolerances f 0.0 c
+  let initialize (f : rhsfn) c = Cvode.(init Adams default_tolerances f 0.0 c)
 
   let reinitialize s t c =
     Cvode.reinit s t c
@@ -64,10 +63,10 @@ module Sundials_cvodes = struct
   type dkysensfn = sensmat -> float -> int -> unit
 
   let initialize (f : rhsfn) params c uS0 =
-    let s = Cvode.(init Adams Functional default_tolerances (f params) 0.0 c) in
+    let s = Cvode.(init Adams default_tolerances (f params) 0.0 c) in
     let np = Array.length uS0 in
     let pbar = RealArray.make np 1. in
-    Sens.(init s EEtolerances Simultaneous
+    Sens.(init s EEtolerances (Simultaneous None)
             ~sens_params:{ pvals = Some params; pbar = Some pbar; plist = None; }
             (AllAtOnce None) uS0);
     Sens.set_err_con s true;
@@ -76,7 +75,7 @@ module Sundials_cvodes = struct
 
   let reinitialize s t c uS0 =
     Cvode.reinit s t c;
-    Sens.reinit s Simultaneous uS0
+    Sens.reinit s (Simultaneous None) uS0
 
   let step s tl c =
     fst (Cvode.solve_one_step s tl c)


### PR DESCRIPTION
The interface to solvers changes in Sundials >= 4.0.0. For example, rather than initialize Cvode with `Functional` or `Newton`, one now passes an optional `~nlsolver` argument to specify a nonlinear solver. This pull request updates Zelus to compile with the upcoming release of Sundials/ML 5.8.0p0. It should be accepted once the new version of Sundials/ML hits opam.